### PR TITLE
Changed the error in 04. Create ./github/workflows/deploy.yml to /.github.. and bellow to below

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git push -u origin main
 base: "/[REPO_NAME]/"
 ```
 
-#### 04. Create ./github/workflows/deploy.yml and add the code bellow
+#### 04. Create /.github/workflows/deploy.yml and add the code below
 > [!WARNING]
 > It is crucial that the `.yml` file has the exact code below. Any typing or spacing errors may cause deployment issues.
 ```yml


### PR DESCRIPTION
This pull request addresses an issue found in line 34 of the `README.md` file:

**Error:**
[Refer to line 34](https://github.com/5Rashmi/vite-deploy/blob/main/README.md#L34)

**Changes Made:**
- Changed `./github` to `/.github`
- Changed `bellow` to `below`

Please review these changes to confirm if they resolve the issue.
