### PR TITLE
Fix Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 18
+        uses: actions/setup-node@v3
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -26,7 +24,7 @@ jobs:
         run: npm run build
 
       - name: Upload production-ready build files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: production-files
           path: ./dist
@@ -39,7 +37,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: production-files
           path: ./dist

--- a/README.md
+++ b/README.md
@@ -49,12 +49,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
+        uses: actions/setup-node@v3
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -63,7 +61,7 @@ jobs:
         run: npm run build
 
       - name: Upload production-ready build files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: production-files
           path: ./dist
@@ -76,7 +74,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: production-files
           path: ./dist


### PR DESCRIPTION
Hey everyone!

Unfortunately, the build job fails with:
- Current runner version: '2.320.0'
- Operating System
- Runner Image
- Runner Image Provisioner
- GITHUB_TOKEN Permissions
- Secret source: Actions
- Prepare workflow directory
- Prepare all required actions
- Getting action download info
- **Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v[2](https://github.com/rdavydov/payment-form/actions/runs/11642104441/job/32421334754#step:1:2)`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/**

![image](https://github.com/user-attachments/assets/c8ecf26b-b8ed-4bb4-98cd-437ffca361e0)

We just need to update deprecated versions from `@v2` to `@v3`.

All credit goes to @dipanjal in https://github.com/ErickKS/vite-deploy/issues/3#issuecomment-2381584583_ - thanks for the info, works like a charm!

I just took the time to make these fixes as a PR.

Good luck,
Roman